### PR TITLE
Make the submodule one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@ Based on https://github.com/owncloud/client/blob/master/doc/building.rst
 
 Run:
 ```bash
-git submodule update --init
-cd client
-git submodule update --init
-cd ...
+git submodule update --init --recursive
 ```
 
 ## Building on Linux


### PR DESCRIPTION
The `cd ...` must also be `..`

Works on my machine TM.

Thanks for https://help.nextcloud.com/t/linux-distribution-packages-for-the-desktop-clients-help-out/2538/3?u=ledfan for pointing out the wrong cd path.
