### PR TITLE
AppImage for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-#
 os: linux
 sudo: true
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 os: linux
 sudo: true
+dist: trusty
+language: cpp
 
-script:
+before_install:
+  - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
+  - sudo sh -c "echo 'deb-src http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
+  - wget http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key
+  - sudo apt-key add - < Release.key
+  - sudo apt-get update
+  - sudo apt-get -y build-dep owncloud-client
+
+install:
   - git submodule update --init --recursive
   - mkdir build-linux
   - cd build-linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+os: linux
+sudo: true
+
+script:
+  - git submodule update --init --recursive
+  - mkdir build-linux
+  - cd build-linux
+  - cmake -D OEM_THEME_DIR=`pwd`/../nextcloudtheme ../client
+  - make
+  - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ sudo: true
 dist: trusty
 language: cpp
 
-install:
+script:
   - bash -ex linux/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+#
 os: linux
 sudo: true
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,5 @@ sudo: true
 dist: trusty
 language: cpp
 
-before_install:
-  - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
-  - sudo sh -c "echo 'deb-src http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
-  - wget http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key
-  - sudo apt-key add - < Release.key
-  - sudo apt-get update
-  - sudo apt-get -y build-dep owncloud-client
-
 install:
-  - git submodule update --init --recursive
-  - mkdir build-linux
-  - cd build-linux
-  - cmake -D OEM_THEME_DIR=`pwd`/../nextcloudtheme ../client
-  - make
-  - sudo make install
+  - linux/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ dist: trusty
 language: cpp
 
 install:
-  - linux/build.sh
+  - bash -ex linux/build.sh

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -114,7 +114,7 @@ VERSION=git$GIT_REV-glibc$GLIBC_NEEDED
 cd .. # Go out of AppImage
 
 mkdir -p ../out/
-generate_type2_appimage
+generate_appimage
 
 ########################################################################
 # Upload the AppDir

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -28,7 +28,7 @@ find /app
 
 export ARCH=$(arch)
 
-APP=NextCloud
+APP=Nextcloud
 LOWERAPP=${APP,,}
 
 GIT_REV=$(git rev-parse --short HEAD)

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
+sudo sh -c "echo 'deb-src http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
+wget http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key
+sudo apt-key add - < Release.key
+sudo apt-get update
+sudo apt-get -y build-dep owncloud-client
+
+git submodule update --init --recursive
+mkdir build-linux
+cd build-linux
+cmake -D CMAKE_INSTALL_PREFIX=/app -D OEM_THEME_DIR=`pwd`/../nextcloudtheme ../client
+make

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
-# sudo sh -c "echo 'deb-src http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
-# wget http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key
-# sudo apt-key add - < Release.key
-# sudo apt-get update
-# sudo apt-get -y build-dep owncloud-client
+sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
+sudo sh -c "echo 'deb-src http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
+wget http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key
+sudo apt-key add - < Release.key
+sudo apt-get update
+sudo apt-get -y build-dep owncloud-client
 
-sudo apt-get -y install debhelper dh-apparmor docutils-common doxygen intltool-debian libjs-sphinxdoc libjs-underscore libqtkeychain1 po-debconf python-docutils python-jinja2 python-markupsafe python-pygments python-roman python-sphinx qtkeychain-dev sphinx-common
+# sudo apt-get -y install debhelper dh-apparmor docutils-common doxygen intltool-debian libjs-sphinxdoc libjs-underscore libqtkeychain1 po-debconf python-docutils python-jinja2 python-markupsafe python-pygments python-roman python-sphinx qtkeychain-dev sphinx-common
   
 git submodule update --init --recursive
 mkdir build-linux

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -84,6 +84,7 @@ rm -rf usr/lib/pkgconfig || true
 find . -name '*.la' | xargs -i rm {}
 strip usr/bin/* usr/lib/* || true
 rm -rf app/ || true
+find . -name libcrypto* | xargs -i rm {}
 
 ########################################################################
 # desktopintegration asks the user on first run to install a menu item

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -32,7 +32,7 @@ LOWERAPP=${APP,,}
 GIT_REV=$(git rev-parse --short HEAD)
 echo $GIT_REV
 
-mkdir -p $HOME/$APP/$APP.AppDir/usr/bin/
+mkdir -p $HOME/$APP/$APP.AppDir/usr/
 
 cd $HOME/$APP/
 
@@ -44,7 +44,7 @@ cd $APP.AppDir
 sudo chown -R $USER /app/
 sed -i -e 's|/app|././|g' /app/bin/nextcloud
 
-cp -r /app/* ./
+cp -r /app/* ./usr/
 
 ########################################################################
 # Copy desktop and icon file to AppDir for AppRun to pick them up
@@ -81,6 +81,7 @@ rm -rf usr/lib/cmake || true
 rm -rf usr/lib/pkgconfig || true
 find . -name '*.la' | xargs -i rm {}
 strip usr/bin/* usr/lib/* || true
+rm -rf app/ || true
 
 ########################################################################
 # desktopintegration asks the user on first run to install a menu item

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
-sudo sh -c "echo 'deb-src http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
-wget http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key
-sudo apt-key add - < Release.key
-sudo apt-get update
-sudo apt-get -y build-dep owncloud-client
+# sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
+# sudo sh -c "echo 'deb-src http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
+# wget http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key
+# sudo apt-key add - < Release.key
+# sudo apt-get update
+# sudo apt-get -y build-dep owncloud-client
 
+sudo apt-get -y install debhelper dh-apparmor docutils-common doxygen intltool-debian libjs-sphinxdoc libjs-underscore libqtkeychain1 po-debconf python-docutils python-jinja2 python-markupsafe python-pygments python-roman python-sphinx qtkeychain-dev sphinx-common
+  
 git submodule update --init --recursive
 mkdir build-linux
 cd build-linux

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -14,5 +14,7 @@ mkdir build-linux
 cd build-linux
 cmake -D CMAKE_INSTALL_PREFIX=/app -D OEM_THEME_DIR=`pwd`/../nextcloudtheme ../client
 make
+find . 
+sudo make install
 find /app
 exit 0

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -69,6 +69,9 @@ cp -r $PLUGINS/* ./usr/lib/qt4/plugins/
 
 copy_deps
 
+# Symlink needed for Fedora
+ln -s /usr/lib/libcrypto.so.10 ./usr/lib/libcrypto.so.1.0.0
+
 ########################################################################
 # Delete stuff that should not go into the AppImage
 ########################################################################

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -44,7 +44,7 @@ cd $APP.AppDir
 sudo chown -R $USER /app/
 sed -i -e 's|/app|././|g' /app/bin/nextcloud
 
-cp /app/bin/nextcloud ./usr/bin/
+cp -r /app/* ./
 
 ########################################################################
 # Copy desktop and icon file to AppDir for AppRun to pick them up

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -17,4 +17,104 @@ make
 find . 
 sudo make install
 find /app
-exit 0
+
+########################################################################
+# Package the binaries built on Travis-CI as an AppImage
+# By Simon Peter 2016
+# For more information, see http://appimage.org/
+########################################################################
+
+export ARCH=$(arch)
+
+APP=NextCloud
+LOWERAPP=${APP,,}
+
+GIT_REV=$(git rev-parse --short HEAD)
+echo $GIT_REV
+
+mkdir -p $HOME/$APP/$APP.AppDir/usr/bin/
+
+cd $HOME/$APP/
+
+wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+. ./functions.sh
+
+cd $APP.AppDir
+
+sudo chown -R $USER /app/
+sed -i -e 's|/app|././|g' /app/bin/nextcloud
+
+cp /app/bin/nextcloud ./usr/bin/
+
+########################################################################
+# Copy desktop and icon file to AppDir for AppRun to pick them up
+########################################################################
+
+get_apprun
+
+cp /app/share/applications/nextcloud.desktop .
+cp /app/share/icons/hicolor/256x256/apps/Nextcloud_ok.png nextcloud.png
+
+########################################################################
+# Copy in the dependencies that cannot be assumed to be available
+# on all target systems
+########################################################################
+
+# FIXME: How to find out which subset of plugins is really needed?
+mkdir -p ./usr/lib/qt4/plugins/
+PLUGINS=/usr/lib/x86_64-linux-gnu/qt4/plugins/
+cp -r $PLUGINS/* ./usr/lib/qt4/plugins/
+
+copy_deps
+
+########################################################################
+# Delete stuff that should not go into the AppImage
+########################################################################
+
+# Delete dangerous libraries; see
+# https://github.com/probonopd/AppImages/blob/master/excludelist
+delete_blacklisted
+
+# We don't bundle the developer stuff
+rm -rf usr/include || true
+rm -rf usr/lib/cmake || true
+rm -rf usr/lib/pkgconfig || true
+find . -name '*.la' | xargs -i rm {}
+strip usr/bin/* usr/lib/* || true
+
+########################################################################
+# desktopintegration asks the user on first run to install a menu item
+########################################################################
+
+get_desktopintegration $LOWERAPP
+
+########################################################################
+# Determine the version of the app; also include needed glibc version
+########################################################################
+
+GLIBC_NEEDED=$(glibc_needed)
+VERSION=git$GIT_REV-glibc$GLIBC_NEEDED
+
+########################################################################
+# Patch away absolute paths; it would be nice if they were relative
+########################################################################
+
+# patch_usr
+# Possibly need to patch additional hardcoded paths away, replace
+# "/usr" with "././" which means "usr/ in the AppDir"
+
+########################################################################
+# AppDir complete
+# Now packaging it as an AppImage
+########################################################################
+
+cd .. # Go out of AppImage
+
+mkdir -p ../out/
+generate_appimage
+
+########################################################################
+# Upload the AppDir
+########################################################################
+
+transfer ../out/*

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -12,3 +12,5 @@ mkdir build-linux
 cd build-linux
 cmake -D CMAKE_INSTALL_PREFIX=/app -D OEM_THEME_DIR=`pwd`/../nextcloudtheme ../client
 make
+find /app
+exit 0

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -84,10 +84,8 @@ rm -rf usr/lib/pkgconfig || true
 find . -name '*.la' | xargs -i rm {}
 strip usr/bin/* usr/lib/* || true
 rm -rf app/ || true
-find . -name libcrypto* | xargs -i rm {}
-
-# Symlink needed for Fedora
-ln -s  /usr/lib64/libcrypto.so.10 ./usr/lib/libcrypto.so.1.0.0
+# Copy, since libssl must be in sync with libcrypto
+cp /lib/x86_64-linux-gnu/libssl.so.1.0.0 usr/lib/ 
 
 ########################################################################
 # desktopintegration asks the user on first run to install a menu item

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+########################################################################
+# Build as per the instructions, but install in /app rather than /usr
+########################################################################
+
 sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
 sudo sh -c "echo 'deb-src http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/Ubuntu_14.04/ /' >> /etc/apt/sources.list.d/owncloud-client.list"
 wget http://download.opensuse.org/repositories/isv:ownCloud:desktop/Ubuntu_14.04/Release.key
@@ -7,8 +11,6 @@ sudo apt-key add - < Release.key
 sudo apt-get update
 sudo apt-get -y build-dep owncloud-client
 
-# sudo apt-get -y install debhelper dh-apparmor docutils-common doxygen intltool-debian libjs-sphinxdoc libjs-underscore libqtkeychain1 po-debconf python-docutils python-jinja2 python-markupsafe python-pygments python-roman python-sphinx qtkeychain-dev sphinx-common
-  
 git submodule update --init --recursive
 mkdir build-linux
 cd build-linux
@@ -53,7 +55,7 @@ cp -r /app/* ./usr/
 get_apprun
 
 cp /app/share/applications/nextcloud.desktop .
-cp /app/share/icons/hicolor/256x256/apps/Nextcloud_ok.png nextcloud.png
+cp /app/share/icons/hicolor/256x256/apps/Nextcloud.png nextcloud.png
 
 ########################################################################
 # Copy in the dependencies that cannot be assumed to be available
@@ -119,3 +121,4 @@ generate_type2_appimage
 ########################################################################
 
 transfer ../out/*
+echo "AppImage has been uploaded to the URL above; use something like GitHub Releases for permanent storage"

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -69,9 +69,6 @@ cp -r $PLUGINS/* ./usr/lib/qt4/plugins/
 
 copy_deps
 
-# Symlink needed for Fedora
-ln -s /usr/lib/libcrypto.so.10 ./usr/lib/libcrypto.so.1.0.0
-
 ########################################################################
 # Delete stuff that should not go into the AppImage
 ########################################################################
@@ -88,6 +85,9 @@ find . -name '*.la' | xargs -i rm {}
 strip usr/bin/* usr/lib/* || true
 rm -rf app/ || true
 find . -name libcrypto* | xargs -i rm {}
+
+# Symlink needed for Fedora
+ln -s /usr/lib/libcrypto.so.10 ./usr/lib/libcrypto.so.1.0.0
 
 ########################################################################
 # desktopintegration asks the user on first run to install a menu item

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -112,7 +112,7 @@ VERSION=git$GIT_REV-glibc$GLIBC_NEEDED
 cd .. # Go out of AppImage
 
 mkdir -p ../out/
-generate_appimage
+generate_type2_appimage
 
 ########################################################################
 # Upload the AppDir

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -87,7 +87,7 @@ rm -rf app/ || true
 find . -name libcrypto* | xargs -i rm {}
 
 # Symlink needed for Fedora
-ln -s /usr/lib/libcrypto.so.10 ./usr/lib/libcrypto.so.1.0.0
+ln -s  /usr/lib64/libcrypto.so.10 ./usr/lib/libcrypto.so.1.0.0
 
 ########################################################################
 # desktopintegration asks the user on first run to install a menu item


### PR DESCRIPTION
This pull request, when merged, will build an [AppImage](http://appimage.org/) on [Travis CI](http://travis-ci.org) and upload it to transfer.sh.

The AppImage contains the Nextcloud client and everything (including Qt) it needs to run that cannot be expected to be part of all target systems (Linux distributions).

To download the AppImage, get the URL from the Travis CI build log, download it, set the executable bit, and run. No installation, no root, no repositories to manage, no system libraries touched, should run on most recent Linux distributions on x86_64 machines.

Some more testing and fine-tuning may be necessary to make this sing on as many target systems with different distributions as possible.

If this is used productively, the AppImage should be stored e.g., in GitHub Releases rather than on transfer.sh.

Here is an example AppImage created this way:
(transfer.sh link removed since it expired long ago)
