### PR TITLE
Add linux dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ git submodule update --init --recursive
 Run:
 
 ```bash
+# If building on Ubuntu
+sudo apt-get install libsqlite3-dev qt5-default libqt5webkit5-dev qt5keychain-dev libssl-dev
+
+# All distributions
 mkdir build-linux
 cd build-linux
 cmake -D OEM_THEME_DIR=`pwd`/../nextcloudtheme ../client
 make
-make install
+sudo make install
 ```
 
 ## Building on OSX


### PR DESCRIPTION
This is most probably non exhaustive but should already help linux users install NextCloud client on their box.