### PR TITLE
Add Travis CI build status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nextcloud desktop client
+# nextcloud desktop client [![Build Status](https://travis-ci.org/nextcloud/client_theming.svg?branch=master)](https://travis-ci.org/nextcloud/client_theming) 
 :computer: theme and build instructions for the nextcloud desktop client
 
 Based on https://github.com/owncloud/client/blob/master/doc/building.rst


### PR DESCRIPTION
Make it easy to find the [Travis CI build status](https://travis-ci.org/nextcloud/client_theming/).