### PR TITLE
snapcraft.yaml: add support for building a snap package

### DIFF
--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -1,0 +1,5 @@
+stage
+snap
+prime
+parts
+*.snap

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -23,9 +23,15 @@ parts:
       - qt5keychain-dev
       - qttools5-dev-tools
     configflags:
-      - -DCMAKE_INSTALL_PREFIX=/usr
-      - -DCMAKE_INSTALL_LIBDIR=/usr/lib
       - -DOEM_THEME_DIR=$SNAPCRAFT_PART_INSTALL/../src/nextcloudtheme
+
+      # XXX: This is an hack to have a kind of bind-mount with absolute prefix.
+      - -DCMAKE_INSTALL_PREFIX=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr
+      - -DCMAKE_INSTALL_LIBDIR=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib
+      - -DSYSCONF_INSTALL_DIR=/snap/$SNAPCRAFT_PROJECT_NAME/current/etc
+    organize:
+      snap/nextcloud-client/current: .
+
     after:
       - desktop-qt5
       - indicator-qt5

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -15,6 +15,7 @@ parts:
     source: ../
     source-subdir: client
     build-packages:
+      - g++
       - libqt5webkit5-dev
       - libsqlite3-dev
       - libssl-dev

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -1,0 +1,62 @@
+name: nextcloud-client
+version: 2.2.4-git
+summary: nextcloud desktop client
+icon: ../client/theme/colored/owncloud-icon.svg
+description: |
+  The ownCloud Desktop Client is a tool to synchronize files from ownCloud
+  Server with your computer.
+
+grade: devel
+confinement: strict
+
+parts:
+  client:
+    plugin: cmake
+    source: ../
+    source-subdir: client
+    build-packages:
+      - libqt5webkit5-dev
+      - libsqlite3-dev
+      - libssl-dev
+      - pkg-config
+      - qt5keychain-dev
+      - qttools5-dev-tools
+    configflags:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_INSTALL_LIBDIR=/usr/lib
+      - -DDOEM_THEME_DIR=../src/nextcloudtheme
+    after:
+      - desktop-qt5
+      - indicator-qt5
+
+  desktop-qt5:
+    stage: [ -./**/lib/*/qt5/**/libappmenu-qt5.so ]
+
+  snapd-xdg-open:
+    source: https://github.com/ubuntu-core/snapd-xdg-open.git
+    source-depth: 1
+    plugin: dump
+    organize:
+      data/xdg-open: bin/xdg-open
+    prime:
+      - bin
+
+apps:
+  nextcloud-client:
+    command: |
+      env LD_LIBRARY_PATH=$SNAP/usr/lib/owncloud:$LD_LIBRARY_PATH
+      desktop-launch owncloud
+    desktop: usr/share/applications/owncloud.desktop
+    plugs:
+      - unity7
+      - home
+      - network
+
+  cmd:
+    command: |
+      env LD_LIBRARY_PATH=$SNAP/usr/lib/owncloud:$LD_LIBRARY_PATH
+      desktop-launch owncloudcmd
+    plugs:
+      - unity7
+      - home
+      - network

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -50,6 +50,8 @@ parts:
 
 apps:
   nextcloud-client:
+    aliases:
+      - nextcloud
     command: |
       env LD_LIBRARY_PATH=$SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
       desktop-launch nextcloud
@@ -62,6 +64,8 @@ apps:
       - network-manager
 
   cmd:
+    aliases:
+      - nextcloudcmd
     command: |
       env LD_LIBRARY_PATH=$SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
       desktop-launch nextcloudcmd

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -1,9 +1,9 @@
 name: nextcloud-client
 version: 2.2.4-git
-summary: nextcloud desktop client
-icon: ../client/theme/colored/owncloud-icon.svg
+summary: Nextcloud Desktop Client
+icon: ../nextcloudtheme/theme/colored/Nextcloud-icon.svg
 description: |
-  The ownCloud Desktop Client is a tool to synchronize files from ownCloud
+  The Nextcloud Desktop Client is a tool to synchronize files from Nextcloud
   Server with your computer.
 
 grade: devel
@@ -24,7 +24,7 @@ parts:
     configflags:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_INSTALL_LIBDIR=/usr/lib
-      - -DDOEM_THEME_DIR=../src/nextcloudtheme
+      - -DOEM_THEME_DIR=$SNAPCRAFT_PART_INSTALL/../src/nextcloudtheme
     after:
       - desktop-qt5
       - indicator-qt5

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -34,10 +34,6 @@ parts:
 
     after:
       - desktop-qt5
-      - indicator-qt5
-
-  desktop-qt5:
-    stage: [ -./**/lib/*/qt5/**/libappmenu-qt5.so ]
 
   xdg-open:
     source: https://github.com/ubuntu-core/snapd-xdg-open.git

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -45,9 +45,9 @@ parts:
 apps:
   nextcloud-client:
     command: |
-      env LD_LIBRARY_PATH=$SNAP/usr/lib/owncloud:$LD_LIBRARY_PATH
-      desktop-launch owncloud
-    desktop: usr/share/applications/owncloud.desktop
+      env LD_LIBRARY_PATH=$SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
+      desktop-launch nextcloud
+    desktop: usr/share/applications/nextcloud.desktop
     plugs:
       - unity7
       - home
@@ -55,8 +55,8 @@ apps:
 
   cmd:
     command: |
-      env LD_LIBRARY_PATH=$SNAP/usr/lib/owncloud:$LD_LIBRARY_PATH
-      desktop-launch owncloudcmd
+      env LD_LIBRARY_PATH=$SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
+      desktop-launch nextcloudcmd
     plugs:
       - unity7
       - home

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -1,12 +1,12 @@
 name: nextcloud-client
 version: 2.2.4-git
-summary: Nextcloud Desktop Client
 icon: ../nextcloudtheme/theme/colored/Nextcloud-icon.svg
+summary: Nextcloud Desktop Client
 description: |
   The Nextcloud Desktop Client is a tool to synchronize files from Nextcloud
   Server with your computer.
 
-grade: devel
+grade: stable
 confinement: strict
 
 parts:

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -52,6 +52,8 @@ apps:
       - unity7
       - home
       - network
+      - network-bind
+      - network-manager
 
   cmd:
     command: |

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -39,7 +39,7 @@ parts:
   desktop-qt5:
     stage: [ -./**/lib/*/qt5/**/libappmenu-qt5.so ]
 
-  snapd-xdg-open:
+  xdg-open:
     source: https://github.com/ubuntu-core/snapd-xdg-open.git
     source-depth: 1
     plugin: dump

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: nextcloud-client
-version: 2.2.4-git
+version: 2.2.4+git
 icon: ../nextcloudtheme/theme/colored/Nextcloud-icon.svg
 summary: Nextcloud Desktop Client
 description: |
@@ -23,6 +23,7 @@ parts:
       - qt5keychain-dev
       - qttools5-dev-tools
     configflags:
+      - -DCMAKE_BUILD_TYPE=Release
       - -DOEM_THEME_DIR=$SNAPCRAFT_PART_INSTALL/../src/nextcloudtheme
 
       # XXX: This is an hack to have a kind of bind-mount with absolute prefix.


### PR DESCRIPTION
The package is generated to be completely [confined](https://snapcraft.io/docs/reference/confinement) right now, and this might cause some minor annoyances, for example: it's not possible to access (sync) .dotted folders, the home is in the `~/snap/nextcloud-client`, password can't be saved to the system keyring.

If you prefer not have these limitations, and make this client to run without any sandbox, we can move to the `classic` confinement, and this will work as it used to be.

The build can also be easily integrated with travis-CI and you can upload the new revisions automatically to the 'edge' channel of the snap store.

If you need any help for this, I'm available.