### PR TITLE
Use snapcraft-preload to redirect requests to the proper target

### DIFF
--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
 
     after:
       - desktop-qt5
-      - preload
+      - snapcraft-preload
 
   xdg-open:
     source: https://github.com/ubuntu-core/snapd-xdg-open.git

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -25,16 +25,13 @@ parts:
     configflags:
       - -DCMAKE_BUILD_TYPE=Release
       - -DOEM_THEME_DIR=$SNAPCRAFT_PART_INSTALL/../src/nextcloudtheme
-
-      # XXX: This is an hack to have a kind of bind-mount with absolute prefix.
-      - -DCMAKE_INSTALL_PREFIX=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr
-      - -DCMAKE_INSTALL_LIBDIR=/snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib
-      - -DSYSCONF_INSTALL_DIR=/snap/$SNAPCRAFT_PROJECT_NAME/current/etc
-    organize:
-      snap/nextcloud-client/current: .
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_INSTALL_LIBDIR=/usr/lib
+      - -DSYSCONF_INSTALL_DIR=/etc
 
     after:
       - desktop-qt5
+      - preload
 
   xdg-open:
     source: https://github.com/ubuntu-core/snapd-xdg-open.git
@@ -51,7 +48,8 @@ apps:
       - nextcloud
     command: |
       env LD_LIBRARY_PATH=$SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
-      desktop-launch nextcloud
+          FONTCONFIG_FILE=$SNAP/etc/fonts/fonts.conf
+          snapcraft-preload nextcloud
     desktop: usr/share/applications/nextcloud.desktop
     plugs:
       - unity7
@@ -65,7 +63,7 @@ apps:
       - nextcloudcmd
     command: |
       env LD_LIBRARY_PATH=$SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
-      desktop-launch nextcloudcmd
+          snapcraft-preload nextcloudcmd
     plugs:
       - unity7
       - home

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -50,7 +50,6 @@ apps:
     command: snapcraft-preload nextcloud
     environment:
       LD_LIBRARY_PATH: $SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
-      FONTCONFIG_FILE: $SNAP/etc/fonts/fonts.conf
     desktop: usr/share/applications/nextcloud.desktop
     plugs:
       - unity7

--- a/linux/snap/snapcraft.yaml
+++ b/linux/snap/snapcraft.yaml
@@ -46,10 +46,11 @@ apps:
   nextcloud-client:
     aliases:
       - nextcloud
-    command: |
-      env LD_LIBRARY_PATH=$SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
-          FONTCONFIG_FILE=$SNAP/etc/fonts/fonts.conf
-          snapcraft-preload nextcloud
+
+    command: snapcraft-preload nextcloud
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
+      FONTCONFIG_FILE: $SNAP/etc/fonts/fonts.conf
     desktop: usr/share/applications/nextcloud.desktop
     plugs:
       - unity7
@@ -61,9 +62,9 @@ apps:
   cmd:
     aliases:
       - nextcloudcmd
-    command: |
-      env LD_LIBRARY_PATH=$SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
-          snapcraft-preload nextcloudcmd
+    command: snapcraft-preload nextcloudcmd
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/nextcloud:$LD_LIBRARY_PATH
     plugs:
       - unity7
       - home


### PR DESCRIPTION
This will allow to get this working also in non-ubuntu
environments, and getting rid of the unneeded startup script.

It fixes issue #95.