### PR TITLE
Add snap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,36 @@
 Based on https://github.com/owncloud/client/blob/master/doc/building.rst 
 
 ## Installing on Ubuntu
-
 ```bash
 sudo add-apt-repository ppa:nextcloud-devs/client
 sudo apt-get update
 sudo apt-get install nextcloud-client
 ```
 
-## Installing on Linux
+## Snaps
 
-## Installing via Snap package ([supported distributions](https://snapcraft.io/docs/core/install))
+### Building the snap
+```bash
+cd linux
+snapcraft
+```
+
+### Installing via Snap package ([supported distributions](https://snapcraft.io/docs/core/install))
 Download the [snap package](https://github.com/nextcloud/client_theming/releases/tag/continuous) for your architecture
 ```bash
 sudo snap install --dangerous nextcloud-client_*.snap
 ```
- 
 Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released. 
 The snap is confined, thus the synced folders will be by default in `~/snap/<version>/`, the client can access to the actual home, but not to the `.dotted` files, use symlinks if you need to.
 
-## Getting repository ready
+## Building on Linux
+
+### Getting repository ready
 
 Run:
 ```bash
 git submodule update --init --recursive
 ```
-
-## Building on Linux
 
 Run:
 
@@ -47,13 +51,7 @@ make
 sudo make install
 ```
 
-### Building the snap
-```bash
-cd linux
-snapcraft
-```
-
-### Building on Debian
+## Building on Debian
 
 Install required packages. 
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,21 @@
 
 Based on https://github.com/owncloud/client/blob/master/doc/building.rst 
 
+## Installing on Linux
+
+Install Nextcloud desktop client in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
+
+    snap install nextcloud-client
+
+Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released. Due to the confinement model snaps provide the synced folders will be located in `~/snap/<version>/` by default. The client can access the actual home, but not the dot files and directories that might contain private or sensitive data.
+
 ## Installing on Ubuntu
+
 ```bash
 sudo add-apt-repository ppa:nextcloud-devs/client
 sudo apt-get update
 sudo apt-get install nextcloud-client
 ```
-
-## Installing via Snap package ([supported distributions](https://snapcraft.io/docs/core/install))
-Download the [snap package](https://github.com/nextcloud/client_theming/releases/tag/continuous) for your architecture
-```bash
-sudo snap install --dangerous nextcloud-client_*.snap
-```
-The snap is confined, thus the synced folders will be by default in `~/snap/<version>/`, the client can access to the actual home, but not to the `.dotted` files, use symlinks if you need to.
 
 ## Getting repository ready
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,6 @@
 
 Based on https://github.com/owncloud/client/blob/master/doc/building.rst 
 
-## Installing on Linux
-
-Install Nextcloud desktop client in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
-
-    snap install nextcloud-client
-
-Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released. Due to the confinement model snaps provide the synced folders will be located in `~/snap/<version>/` by default. The client can access the actual home, but not the dot files and directories that might contain private or sensitive data.
-
 ## Installing on Ubuntu
 
 ```bash
@@ -20,6 +12,17 @@ sudo add-apt-repository ppa:nextcloud-devs/client
 sudo apt-get update
 sudo apt-get install nextcloud-client
 ```
+
+## Installing on Linux
+
+## Installing via Snap package ([supported distributions](https://snapcraft.io/docs/core/install))
+Download the [snap package](https://github.com/nextcloud/client_theming/releases/tag/continuous) for your architecture
+```bash
+sudo snap install --dangerous nextcloud-client_*.snap
+```
+ 
+Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released. 
+The snap is confined, thus the synced folders will be by default in `~/snap/<version>/`, the client can access to the actual home, but not to the `.dotted` files, use symlinks if you need to.
 
 ## Getting repository ready
 


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of stable desktop applications will also be available via the desktop Software Center, improving the discoverability of your software. Your software can be installed with a simple `snap install nextcloud-client` simplifying the installation instructions for your users. Once the snap is released into the stable channel in the store it will appear in the desktop Software Center.