### PR TITLE
Build with Qt5 and the KDE Frameworks

### DIFF
--- a/linux/debian/nextcloud-client/debian.trusty/control
+++ b/linux/debian/nextcloud-client/debian.trusty/control
@@ -2,29 +2,8 @@ Source: nextcloud-client
 Section: contrib/devel
 Priority: optional
 Maintainer: István Váradi <ivaradi@varadiistvan.hu>
-Build-Depends: cmake,
-               debhelper,
-               cdbs,
-               dh-python,
-               extra-cmake-modules (>= 5.16),
-               kdelibs5-dev,
-               kio-dev,
-               libcmocka-dev,
-               libhttp-dav-perl,
-               libinotify-dev [kfreebsd-any],
-               libqt5webkit5-dev,
-               libsqlite3-dev,
-               libssl-dev (>> 1.0.0),
-               zlib1g-dev,
-               optipng,
-               pkg-kde-tools,
-               python-sphinx | python3-sphinx,
-               python3-all,
-               qt5keychain-dev,
-               qtdeclarative5-dev,
-               qttools5-dev,
-               qttools5-dev-tools,
-               xvfb
+Build-Depends: debhelper (>= 9), cdbs, cmake, libssl-dev (>= 1.0.0), libsqlite3-dev (>=3.8.0),
+    qtkeychain-dev (>=0.7.0), libqtwebkit-dev, pkg-config
 Standards-Version: 3.9.8
 Homepage: https://github.com/nextcloud/client_theming
 #Vcs-Git: git://anonscm.debian.org/collab-maint/nextcloud-client.git

--- a/linux/debian/nextcloud-client/debian.yakkety/changelog
+++ b/linux/debian/nextcloud-client/debian.yakkety/changelog
@@ -1,41 +1,41 @@
-nextcloud-client (2.3.1-1.0~xenial1) xenial; urgency=medium
+nextcloud-client (2.3.1-1.0~yakkety1) yakkety; urgency=medium
 
   * New upstream version
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Thu, 23 Mar 2017 19:07:36 +0100
 
-nextcloud-client (2.3.0-1.0~xenial1) xenial; urgency=medium
+nextcloud-client (2.3.0-1.0~yakkety1) yakkety; urgency=medium
 
   * New upstream version
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Tue, 21 Mar 2017 19:34:13 +0100
 
-nextcloud-client (2.2.4-1.4~xenial1) xenial; urgency=medium
+nextcloud-client (2.2.4-1.4~yakkety1) yakkety; urgency=medium
 
   * The locale-specific icon names are correct too
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Tue, 7 Feb 2017 19:55:40 +0100
 
-nextcloud-client (2.2.4-1.3~xenial1) xenial; urgency=medium
+nextcloud-client (2.2.4-1.3~yakkety1) yakkety; urgency=medium
 
   * Caja syncstate plugin is built.
   * The syncstate plugin has application-specific name
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Fri, 27 Jan 2017 19:34:18 +0100
 
-nextcloud-client (2.2.4-1.2~xenial1) xenial; urgency=medium
+nextcloud-client (2.2.4-1.2~yakkety1) yakkety; urgency=medium
 
   * Fixed appname in the Nemo syncstate extension.
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Thu, 19 Jan 2017 16:46:50 +0100
 
-nextcloud-client (2.2.4-1.1~xenial1) xenial; urgency=medium
+nextcloud-client (2.2.4-1.1~yakkety1) yakkety; urgency=medium
 
   * Added Nautilus and Nemo syncstate extensions.
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Tue, 17 Jan 2017 19:55:32 +0100
 
-nextcloud-client (2.2.4-1.0~xenial1) xenial; urgency=medium
+nextcloud-client (2.2.4-1.0~yakkety1) yakkety; urgency=medium
 
   * Initial release.
 

--- a/linux/debian/nextcloud-client/debian.yakkety/nextcloud-client-dolphin.install
+++ b/linux/debian/nextcloud-client/debian.yakkety/nextcloud-client-dolphin.install
@@ -1,0 +1,4 @@
+usr/lib/*/libnextclouddolphinpluginhelper.so
+usr/lib/*/qt5/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
+usr/lib/*/qt5/plugins/nextclouddolphinactionplugin.so
+usr/share/kservices5/nextclouddolphinactionplugin.desktop

--- a/linux/debian/nextcloud-client/debian.zesty/nextcloud-client-dolphin.install
+++ b/linux/debian/nextcloud-client/debian.zesty/nextcloud-client-dolphin.install
@@ -1,0 +1,4 @@
+usr/lib/*/libnextclouddolphinpluginhelper.so
+usr/lib/*/qt5/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
+usr/lib/*/qt5/plugins/nextclouddolphinactionplugin.so
+usr/share/kservices5/nextclouddolphinactionplugin.desktop

--- a/linux/debian/nextcloud-client/debian/changelog
+++ b/linux/debian/nextcloud-client/debian/changelog
@@ -1,41 +1,41 @@
-nextcloud-client (2.3.1-1.0~yakkety1) yakkety; urgency=medium
+nextcloud-client (2.3.1-1.0~xenial1) xenial; urgency=medium
 
   * New upstream version
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Thu, 23 Mar 2017 19:07:36 +0100
 
-nextcloud-client (2.3.0-1.0~yakkety1) yakkety; urgency=medium
+nextcloud-client (2.3.0-1.0~xenial1) xenial; urgency=medium
 
   * New upstream version
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Tue, 21 Mar 2017 19:34:13 +0100
 
-nextcloud-client (2.2.4-1.4~yakkety1) yakkety; urgency=medium
+nextcloud-client (2.2.4-1.4~xenial1) xenial; urgency=medium
 
   * The locale-specific icon names are correct too
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Tue, 7 Feb 2017 19:55:40 +0100
 
-nextcloud-client (2.2.4-1.3~yakkety1) yakkety; urgency=medium
+nextcloud-client (2.2.4-1.3~xenial1) xenial; urgency=medium
 
   * Caja syncstate plugin is built.
   * The syncstate plugin has application-specific name
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Fri, 27 Jan 2017 19:34:18 +0100
 
-nextcloud-client (2.2.4-1.2~yakkety1) yakkety; urgency=medium
+nextcloud-client (2.2.4-1.2~xenial1) xenial; urgency=medium
 
   * Fixed appname in the Nemo syncstate extension.
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Thu, 19 Jan 2017 16:46:50 +0100
 
-nextcloud-client (2.2.4-1.1~yakkety1) yakkety; urgency=medium
+nextcloud-client (2.2.4-1.1~xenial1) xenial; urgency=medium
 
   * Added Nautilus and Nemo syncstate extensions.
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Tue, 17 Jan 2017 19:55:32 +0100
 
-nextcloud-client (2.2.4-1.0~yakkety1) yakkety; urgency=medium
+nextcloud-client (2.2.4-1.0~xenial1) xenial; urgency=medium
 
   * Initial release.
 

--- a/linux/debian/nextcloud-client/debian/control
+++ b/linux/debian/nextcloud-client/debian/control
@@ -78,3 +78,10 @@ Depends: nextcloud-client (>=${binary:Version}), libnextcloudsync0, python-caja,
 Description: Caja plugin for Nextcloud
  This package contains a Caja plugin to display
  synchronization status icons for Nextcloud files.
+
+Package: nextcloud-client-dolphin
+Architecture: any
+Depends: dolphin (>= 4:15.12.1), libnextcloudsync0 (= ${binary:Version}), nextcloud-client, ${misc:Depends}, ${shlibs:Depends}
+Description: Dolphin plugin for Nextcloud
+ This package contains a Dolphin plugin to display
+ synchronization status icons for Nextcloud files.

--- a/linux/debian/nextcloud-client/debian/nextcloud-client-dolphin.install
+++ b/linux/debian/nextcloud-client/debian/nextcloud-client-dolphin.install
@@ -1,0 +1,4 @@
+usr/lib/*/libnextclouddolphinpluginhelper.so
+usr/lib/*/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
+usr/lib/*/plugins/nextclouddolphinactionplugin.so
+usr/share/kservices5/nextclouddolphinactionplugin.desktop

--- a/linux/debian/nextcloud-client/debian/nextcloud-client-dolphin.lintian-overrides
+++ b/linux/debian/nextcloud-client/debian/nextcloud-client-dolphin.lintian-overrides
@@ -1,0 +1,2 @@
+nextcloud-client-dolphin: package-name-doesnt-match-sonames
+nextcloud-client-dolphin: shlib-without-versioned-soname

--- a/linux/debian/nextcloud-client/debian/nextcloud-client-dolphin.triggers
+++ b/linux/debian/nextcloud-client/debian/nextcloud-client-dolphin.triggers
@@ -1,0 +1,1 @@
+activate-noawait ldconfig

--- a/linux/debian/nextcloud-client/debian/nextcloud-client.lintian-overrides
+++ b/linux/debian/nextcloud-client/debian/nextcloud-client.lintian-overrides
@@ -1,2 +1,3 @@
 nextcloud-client: binary-or-shlib-defines-rpath
 nextcloud-client: binary-without-manpage
+nextcloud-client: license-problem-convert-utf-code

--- a/linux/debian/nextcloud-client/debian/source/lintian-overrides
+++ b/linux/debian/nextcloud-client/debian/source/lintian-overrides
@@ -6,3 +6,4 @@ nextcloud-client source: source-is-missing client/doc/ocdoc/_shared_assets/theme
 nextcloud-client source: source-is-missing client/doc/ocdoc/_shared_assets/themes/owncloud_release/static/bootstrap.js line length is 22206 characters (>512)
 nextcloud-client source: source-is-missing client/doc/ocdoc/_shared_assets/themes/owncloud_release/static/jquery.js line length is 32412 characters (>512)
 nextcloud-client source: source-is-missing client/doc/ocdoc/_shared_assets/themes/owncloud_org/static/js/jquery-1.11.0.min.js
+nextcloud-client source: license-problem-convert-utf-code

--- a/linux/debian/scripts/build.sh
+++ b/linux/debian/scripts/build.sh
@@ -17,6 +17,6 @@ pushd /
 
 "${scriptdir}/create_debdir.sh" "${package}" "${tag}" "${version}" "${distribution}"
 
-(cd "${BUILDAREA}/${package}_${version}"; debuild "$@")
+(cd "${BUILDAREA}/${package}_${version}"; EDITOR=true dpkg-source --commit . local-changes; debuild "$@")
 
 popd


### PR DESCRIPTION
For Ubuntu Xenial, Yakkety and Zesty the package is now built with Qt5 and the KDE Frameworks to enable the bandwidth limitation feature (working with Qt5 only, see https://help.nextcloud.com/t/ppa-ubuntu-bandwidth-limitation-not-working/11420) and the Dolphin file manager plugin (see #130).
