### PR TITLE
Fix the handling of distribution-specific files in Ubuntu Travis build 

### DIFF
--- a/linux/debian/travis-build.sh
+++ b/linux/debian/travis-build.sh
@@ -37,7 +37,7 @@ elif [ "$TRAVIS_BUILD_STEP" == "script" ]; then
 
         cp -a linux/debian/nextcloud-client/debian .
         if test -d linux/debian/nextcloud-client/debian.${distribution}; then
-            cp -a linux/debian/nextcloud-client/debian.${distribution} debian
+            tar cf - -C linux/debian/nextcloud-client/debian.${distribution} . | tar xf - -C debian
         fi
 
         linux/debian/scripts/git2changelog.py /tmp/tmpchangelog ${distribution}


### PR DESCRIPTION
The Ubuntu source packages contain some configuration files that are specific to a certain distribution (e.g. Yakkety or Zesty). This Travis build script does not currently overwrite the default files with these, resulting in source packages that cannot be built by Launchpad.

This pull request fixes this problem.