### PR TITLE
Minor fixes for Ubuntu/Debian packaging

### DIFF
--- a/linux/debian/scripts/git2changelog.py
+++ b/linux/debian/scripts/git2changelog.py
@@ -3,6 +3,7 @@
 import subprocess
 import re
 import sys
+import datetime
 
 baseVersion="2.2.4"
 distribution="yakkety"
@@ -14,8 +15,7 @@ def collectEntries(baseCommit, baseVersion):
 
     args = ["git", "log",
             "--format=%h%x09%an%x09%ae%x09%aD%x09%ad%x09%s",
-            "--date=format:%Y%m%d.%H%M%S",
-            "--author-date-order", "--reverse"]
+            "--date=unix", "--author-date-order", "--reverse"]
     try:
         output = subprocess.check_output(args + [baseCommit + ".."])
     except:
@@ -23,6 +23,7 @@ def collectEntries(baseCommit, baseVersion):
 
     for line in output.splitlines():
         (commit, name, email, date, revdate, subject) = line.split("\t")
+        revdate = datetime.datetime.utcfromtimestamp(long(revdate)).strftime("%Y%m%d.%H%M%S")
 
         for tag in subprocess.check_output(["git", "tag",
                                             "--points-at",

--- a/linux/debian/travis-build.sh
+++ b/linux/debian/travis-build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -xe
+shopt -s extglob
 
 TRAVIS_BUILD_STEP="$1"
 

--- a/linux/debian/travis-build.sh
+++ b/linux/debian/travis-build.sh
@@ -74,7 +74,7 @@ elif [ "$TRAVIS_BUILD_STEP" == "snap_store_deploy" ]; then
     cd ..
 
     if test "$encrypted_585e03da75ed_key" -a "$encrypted_585e03da75ed_iv"; then
-        for changes in nextcloud-client*_source.changes; do
+        for changes in nextcloud-client_*~+([a-z])1_source.changes; do
             dput $PPA $changes > /dev/null
         done
     fi


### PR DESCRIPTION
This pull request contains two smaller fixes for the automatic packaging:

- The version numbers are generated from the commit timestamp. The current implementation does not take into account time zones, so it is possible that it generates a version for newer commit that is less than the version generated for a previous commit. The fix is to always convert the commit timestamp to UTC ensuring that it is monotonically increasing.

- With the introduction of the Debian source package, it is uploaded to Launchpad along with the Ubuntu ones. Launchpad thus rejects the package, which is not nice (although harmless). It is also fixed.