### PR TITLE
Remove lecagy glibc version hack

### DIFF
--- a/linux/appimage-build.sh
+++ b/linux/appimage-build.sh
@@ -96,7 +96,7 @@ get_desktopintegration $LOWERAPP
 # Determine the version of the app
 ########################################################################
 
-VERSION=git$GIT_REV
+VERSION=git.$GIT_REV
 
 ########################################################################
 # Patch away absolute paths; it would be nice if they were relative

--- a/linux/appimage-build.sh
+++ b/linux/appimage-build.sh
@@ -93,11 +93,10 @@ cp /lib/x86_64-linux-gnu/libssl.so.1.0.0 usr/lib/
 get_desktopintegration $LOWERAPP
 
 ########################################################################
-# Determine the version of the app; also include needed glibc version
+# Determine the version of the app
 ########################################################################
 
-GLIBC_NEEDED=$(glibc_needed)
-VERSION=git$GIT_REV-glibc$GLIBC_NEEDED
+VERSION=git$GIT_REV
 
 ########################################################################
 # Patch away absolute paths; it would be nice if they were relative


### PR DESCRIPTION
This commit removes the no longer necessary code that included the glibc version the binary in the AppImage used, as this has been merged into `functions.sh` in the upstream AppImages project.