### PR TITLE
AppImage Qt5.8

### DIFF
--- a/linux/AppImage/Dockerfile
+++ b/linux/AppImage/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update
 
 RUN apt-get install -y wget libsqlite3-dev libssl-dev cmake git software-properties-common build-essential mesa-common-dev fuse
 
-RUN add-apt-repository -y ppa:beineri/opt-qt562-trusty
+RUN add-apt-repository -y ppa:beineri/opt-qt58-trusty
 
 RUN apt-get update
 
-RUN apt-get install -y qt56base qt56tools
+RUN apt-get install -y qt58base qt58tools

--- a/linux/AppImage/Dockerfile
+++ b/linux/AppImage/Dockerfile
@@ -2,12 +2,11 @@ FROM ubuntu:trusty
 
 MAINTAINER Roeland Jago Douma <roeland@famdouma.nl>
 
-RUN apt-get update
+RUN apt-get update && \
+    apt-get install -y wget libsqlite3-dev libssl-dev cmake git \
+        software-properties-common build-essential mesa-common-dev fuse rsync
 
-RUN apt-get install -y wget libsqlite3-dev libssl-dev cmake git software-properties-common build-essential mesa-common-dev fuse
+RUN add-apt-repository -y ppa:beineri/opt-qt58-trusty && \
+    apt-get update && \
+    apt-get install -y qt58base qt58tools
 
-RUN add-apt-repository -y ppa:beineri/opt-qt58-trusty
-
-RUN apt-get update
-
-RUN apt-get install -y qt58base qt58tools

--- a/linux/AppImage/Dockerfile
+++ b/linux/AppImage/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:trusty
+
+MAINTAINER Roeland Jago Douma <roeland@famdouma.nl>
+
+RUN apt-get update
+
+RUN apt-get install -y wget libsqlite3-dev libssl-dev cmake git software-properties-common build-essential mesa-common-dev fuse
+
+RUN add-apt-repository -y ppa:beineri/opt-qt562-trusty
+
+RUN apt-get update
+
+RUN apt-get install -y qt56base qt56tools

--- a/linux/AppImage/build.sh
+++ b/linux/AppImage/build.sh
@@ -1,7 +1,7 @@
 #/bin/bash
 
-#Get Qt-5.6.2
-source /opt/qt56/bin/qt56-env.sh
+#Get Qt-5.8
+source /opt/qt58/bin/qt58-env.sh
 
 #QtKeyChain
 cd
@@ -11,7 +11,7 @@ git checkout v0.8.0
 mkdir build
 cd build
 cmake -D CMAKE_INSTALL_PREFIX=/app ../
-make
+make -j4
 make install
 
 #Build client
@@ -22,9 +22,9 @@ cmake -D CMAKE_INSTALL_PREFIX=/app \
     -D NO_SHIBBOLETH=1 \
     -D OEM_THEME_DIR=/home/client/nextcloudtheme \
     -DMIRALL_VERSION_SUFFIX=beta \
-    -DMIRALL_VERSION_BUILD=13 \
+    -DMIRALL_VERSION_BUILD=14 \
     /home/client/client
-make
+make -j4
 make install
 
 #Set info
@@ -56,7 +56,7 @@ cp /app/share/icons/hicolor/256x256/apps/Nextcloud.png nextcloud.png
 
 #Copy qt plugins
 mkdir -p ./usr/lib/qt5/plugis
-cp -r /opt/qt56/plugins ./usr/lib/qt5/plugins
+cp -r /opt/qt58/plugins ./usr/lib/qt5/plugins
 
 #Copy dependencies
 copy_deps
@@ -74,8 +74,8 @@ rm -rf app/ || true
 cp /lib/x86_64-linux-gnu/libssl.so.1.0.0 usr/lib/
 
 
-#Move qt5.6 libs to the right location
-mv ./opt/qt56/lib/* ./usr/lib/x86_64-linux-gnu/
+#Move qt5.8 libs to the right location
+mv ./opt/qt58/lib/* ./usr/lib/
 rm -rf ./opt/
 
 #Move sync exlucde to right location

--- a/linux/AppImage/build.sh
+++ b/linux/AppImage/build.sh
@@ -1,0 +1,93 @@
+#/bin/bash
+
+#Get Qt-5.6.2
+source /opt/qt56/bin/qt56-env.sh
+
+#QtKeyChain
+cd
+git clone https://github.com/frankosterfeld/qtkeychain.git
+cd qtkeychain
+git checkout v0.8.0
+mkdir build
+cd build
+cmake -D CMAKE_INSTALL_PREFIX=/app ../
+make
+make install
+
+#Build client
+cd
+mkdir build-client
+cd build-client
+cmake -D CMAKE_INSTALL_PREFIX=/app \
+    -D NO_SHIBBOLETH=1 \
+    -D OEM_THEME_DIR=/home/client/nextcloudtheme \
+    -DMIRALL_VERSION_SUFFIX=beta \
+    -DMIRALL_VERSION_BUILD=13 \
+    /home/client/client
+make
+make install
+
+#Set info
+ARCH=$(arch)
+APP=Nextcloud
+LOWERAPP=${APP,,}
+VERSION=2.3.2-beta
+
+#Create skeleton
+mkdir -p $HOME/$APP/$APP.AppDir/usr/
+cd $HOME/$APP/
+
+#Fetch appimage functions
+wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+. ./functions.sh
+
+cd $APP.AppDir
+
+#clean binary
+sed -i -e 's|/app|././|g' /app/bin/nextcloud
+
+# Copy installed stuff
+cp -r /app/* ./usr/
+
+get_apprun
+
+cp /app/share/applications/nextcloud.desktop .
+cp /app/share/icons/hicolor/256x256/apps/Nextcloud.png nextcloud.png
+
+#Copy qt plugins
+mkdir -p ./usr/lib/qt5/plugis
+cp -r /opt/qt56/plugins ./usr/lib/qt5/plugins
+
+#Copy dependencies
+copy_deps
+
+delete_blacklisted
+
+# We don't bundle the developer stuff
+rm -rf usr/include || true
+rm -rf usr/lib/cmake || true
+rm -rf usr/lib/pkgconfig || true
+find . -name '*.la' | xargs -i rm {}
+strip usr/bin/* usr/lib/* || true
+rm -rf app/ || true
+# Copy, since libssl must be in sync with libcrypto
+cp /lib/x86_64-linux-gnu/libssl.so.1.0.0 usr/lib/
+
+
+#Move qt5.6 libs to the right location
+mv ./opt/qt56/lib/* ./usr/lib/x86_64-linux-gnu/
+rm -rf ./opt/
+
+#Move sync exlucde to right location
+mv ./usr/etc/Nextcloud/sync-exclude.lst ./usr/bin/
+
+#desktop intergration
+get_desktopintegration $LOWERAPP
+
+#Generate the appimage
+cd ..
+mkdir -p ../out/
+generate_type2_appimage
+
+#move appimag
+mv ../out/ /home/client/

--- a/linux/appimage-build.sh
+++ b/linux/appimage-build.sh
@@ -14,10 +14,10 @@ sudo apt-get -y build-dep owncloud-client
 git submodule update --init --recursive
 mkdir build-linux
 cd build-linux
-cmake -D CMAKE_INSTALL_PREFIX=/app -D OEM_THEME_DIR=`pwd`/../nextcloudtheme ../client
+cmake -D CMAKE_INSTALL_PREFIX=/usr -D OEM_THEME_DIR=`pwd`/../nextcloudtheme ../client
 make
 find .
-sudo make install
+sudo make install DESTDIR=/app
 find /app
 
 ########################################################################


### PR DESCRIPTION
* Dockerfile to have an image with the basics (Qt5.8 etc)
* build.sh to build it all

So the steps:

1. `docker build -t nextcloud-client-appimage:5.8 linux/AppImage`
2. `docker run -t -i --rm --cap-add SYS_ADMIN --cap-add MKNOD --device=/dev/fuse --security-opt apparmor:unconfined -v "$PWD:/home/client" nextcloud-client-appimage:5.8`
3. `/home/client/linux/AppImage/build.sh`

@probonopd as discussed.
Maybe we should merge this with the already running stuff on travis? (Or just use this to build and add a container to our drone ci?)

Feedback welcome.