### PR TITLE
OBS beta packages are in a different project

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,35 @@ If you always want the latest versions (including the betas), add both
 repositories. If you want only the stable version, add the non-beta
 repository only.
 
+## Installing on Debian
+
+You need to add to `sources.list` or a separate source list file one of the source lines below corresponding to your Debian version:
+
+`deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_9.0_update/ /`
+`deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_9.0/ /`
+`deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_8.0/ /`
+`deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_7.0/ /`
+
+For example (as root):
+
+```bash
+echo 'deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_9.0/ /' > /etc/apt/sources.list.d/nextcloud-client.list
+apt-get update
+apt-get install nextcloud-client
+```
+
+### Beta packages
+
+Beta packages are also available:
+
+`deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_9.0_update/ /`
+`deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_9.0/ /`
+`deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_8.0/ /`
+`deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_7.0/ /
+`
+
+If you always want the latest versions (including the betas), add both the normal and the beta repositories. If you want only the stable version, add the non-beta repository only.
+
 ## Snaps
 
 ### Building the snap

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ repository only.
 
 You need to add to `sources.list` or a separate source list file one of the source lines below corresponding to your Debian version:
 
-`deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_9.0_update/ /`
-`deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_9.0/ /`
-`deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_8.0/ /`
-`deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_7.0/ /`
+```
+deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_9.0_update/ /
+deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_9.0/ /
+deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_8.0/ /
+deb http://download.opensuse.org/repositories/home:/ivaradi/Debian_7.0/ /
+```
 
 For example (as root):
 
@@ -47,11 +49,12 @@ apt-get install nextcloud-client
 
 Beta packages are also available:
 
-`deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_9.0_update/ /`
-`deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_9.0/ /`
-`deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_8.0/ /`
-`deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_7.0/ /
-`
+```
+deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_9.0_update/ /
+deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_9.0/ /
+deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_8.0/ /
+deb http://download.opensuse.org/repositories/home:/ivaradi:/beta/Debian_7.0/ /
+```
 
 If you always want the latest versions (including the betas), add both the normal and the beta repositories. If you want only the stable version, add the non-beta repository only.
 

--- a/linux/debian/scripts/create_debdir.sh
+++ b/linux/debian/scripts/create_debdir.sh
@@ -74,3 +74,7 @@ tar cf - -C "${scriptdir}/../${package}/debian" . | tar xf - -C "${packagedir}/d
 if test -d "${scriptdir}/../${package}/debian.${distribution}"; then
     tar cf - -C "${scriptdir}/../${package}/debian.${distribution}" . | tar xf - -C "${packagedir}/debian"
 fi
+
+"${scriptdir}/git2changelog.py"  /tmp/git2changelog "${distribution}"
+mv "${packagedir}/debian/changelog" "${packagedir}/debian/changelog.old"
+cat /tmp/git2changelog "${packagedir}/debian/changelog.old" > "${packagedir}/debian/changelog"

--- a/linux/debian/travis-build.sh
+++ b/linux/debian/travis-build.sh
@@ -9,8 +9,8 @@ PPA=ppa:nextcloud-devs/client
 PPA_BETA=ppa:nextcloud-devs/client-beta
 
 OBS_PROJECT=home:ivaradi
+OBS_PROJECT_BETA=home:ivaradi:beta
 OBS_PACKAGE=nextcloud-client
-OBS_PACKAGE_BETA=nextcloud-client-beta
 
 if [ "$TRAVIS_BUILD_STEP" == "install" ]; then
     sudo apt-get update -q
@@ -90,7 +90,7 @@ elif [ "$TRAVIS_BUILD_STEP" == "snap_store_deploy" ]; then
 
     if test "$kind" = "beta"; then
         PPA=$PPA_BETA
-        OBS_PACKAGE=$OBS_PACKAGE_BETA
+        OBS_PROJECT=$OBS_PROJECT_BETA
     fi
     OBS_SUBDIR="${OBS_PROJECT}/${OBS_PACKAGE}"
 


### PR DESCRIPTION
Earlier the same project but a different package was used for the beta clients, but this resulted in them being in the same Debian repository as the non-beta packages. This patch uses a different project, so users can decide if they want the betas or only the stable versions.

I also added Debian installation instructions to the README.