### PR TITLE
Update client to release v2.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   - BUILD_TYPE=snap
   - BUILD_TYPE=snap ARCH=i386
   - BUILD_TYPE=debian
+  - BUILD_TYPE=win
 
 before_install:
   - linux/travis-build.sh before_install

--- a/README.md
+++ b/README.md
@@ -194,4 +194,4 @@ When we build releases there are two additional cmake parameters to consider:
 * `-DMIRALL_VERSION_SUFFIX=<STRING>`: for a generic suffix name such as `beta` or `rc1`
 * `-DMIRALL_VERSION_BUILD=<INT>`: an internal build number. Should be strictly increasing. This allows update detection from `rc` to `final`
 
-Note that this had mostly usage on Windows and OS X. On linux the package manager will take care of all this.
+Note that this had mostly usage on Windows and OS X. On Linux the package manager will take care of all this.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ Build it:
 docker build -t nextcloud-client-win32:<version> client/admin/win/docker/
 ```
 
+_Note: if you encounter an error at this step that the MinGW repository was not found, apply the patch at_ `win/opensuse-mingw-repo-location.patch` _and try again:_
+
+```bash
+cd client
+patch -p1 < ../win/opensuse-mingw-repo-location.patch
+cd ..
+```
+
 ### Building the binary
 
 ```bash

--- a/linux/debian/nextcloud-client/debian/patches/fix-application-icon-name.patch
+++ b/linux/debian/nextcloud-client/debian/patches/fix-application-icon-name.patch
@@ -23,8 +23,8 @@ Forwarded: <no|not-needed|url proving that it has been forwarded>
 Reviewed-By: <name and email of someone who approved the patch>
 Last-Update: 2016-12-20
 
---- nextcloud-client-2.3.1.orig/client/mirall.desktop.in
-+++ nextcloud-client-2.3.1/client/mirall.desktop.in
+--- nextcloud-client-2.3.3.orig/client/mirall.desktop.in
++++ nextcloud-client-2.3.3/client/mirall.desktop.in
 @@ -5,7 +5,7 @@
  Name=@APPLICATION_NAME@ desktop sync client 
  Comment=@APPLICATION_NAME@ desktop synchronization client
@@ -34,7 +34,7 @@ Last-Update: 2016-12-20
  Keywords=@APPLICATION_NAME@;syncing;file;sharing;
  X-GNOME-Autostart-Delay=3
  
-@@ -962,168 +962,168 @@
+@@ -184,177 +184,177 @@
  Comment[oc]=@APPLICATION_NAME@ sincronizacion del client
  GenericName[oc]=Dorsièr de Sincronizacion
  Name[oc]=@APPLICATION_NAME@ sincronizacion del client
@@ -104,6 +104,11 @@ Last-Update: 2016-12-20
  Name[fr]=Client de synchronisation @APPLICATION_NAME@
 -Icon[fr]=@APPLICATION_EXECUTABLE@
 +Icon[fr]=@APPLICATION_SHORTNAME@
+ Comment[gl]=@APPLICATION_NAME@ cliente de sincronización para escritorio
+ GenericName[gl]=Sincronizar Cartafol
+ Name[gl]=@APPLICATION_NAME@ cliente de sincronización para escritorio
+-Icon[gl]=@APPLICATION_EXECUTABLE@
++Icon[gl]=@APPLICATION_SHORTNAME@
  Comment[he]=@APPLICATION_NAME@ לקוח סנכון שולחן עבודה
  GenericName[he]=סנכון תיקייה
  Name[he]=@APPLICATION_NAME@ לקוח סנכרון שולחן עבודה 
@@ -207,7 +212,13 @@ Last-Update: 2016-12-20
  Name[zh_CN]=@APPLICATION_NAME@ 桌面同步客户端
 -Icon[zh_CN]=@APPLICATION_EXECUTABLE@
 +Icon[zh_CN]=@APPLICATION_SHORTNAME@
+ Comment[zh_HK]=桌面版同步客户端
  GenericName[zh_TW]=資料夾同步
+ Comment[es_AR]=Cliente de sincronización para escritorio @APPLICATION_NAME@ 
+ GenericName[es_AR]=Sincronización de directorio
+ Name[es_AR]=Cliente de sincronización para escritorio @APPLICATION_NAME@ 
+-Icon[es_AR]=@APPLICATION_EXECUTABLE@
++Icon[es_AR]=@APPLICATION_SHORTNAME@
  Comment[lt_LT]=@APPLICATION_NAME@ darbalaukio sinchronizavimo programa
  GenericName[lt_LT]=Katalogo sinchnorizacija
  Name[lt_LT]=@APPLICATION_NAME@ darbalaukio programa

--- a/linux/debian/scripts/git2changelog.cfg
+++ b/linux/debian/scripts/git2changelog.cfg
@@ -1,0 +1,3 @@
+[versionhack]
+commit = 30986d6
+tag = v2.3.3-beta

--- a/linux/debian/scripts/git2changelog.py
+++ b/linux/debian/scripts/git2changelog.py
@@ -4,12 +4,37 @@ import subprocess
 import re
 import sys
 import datetime
+import os
+import ConfigParser
 
 distribution="yakkety"
 
 versionTagRE = re.compile("^v([0-9]+((\.[0-9]+)+))(-(.+))?$")
 
+def processVersionTag(tag):
+    m = versionTagRE.match(tag)
+    if m:
+        return (m.group(1), "release" if m.group(4) is None else "beta")
+    else:
+        return None
+
 def collectEntries(baseCommit, baseVersion, kind):
+    scriptdir = os.path.dirname(__file__)
+    configPath = os.path.join(scriptdir, "git2changelog.cfg")
+
+    newVersionCommit = None
+    newVersionTag = None
+    newVersionOrigTag = None
+
+    if os.path.exists(configPath):
+        config = ConfigParser.SafeConfigParser()
+        config.read(configPath)
+        if config.has_section("versionhack"):
+            if config.has_option("versionhack", "commit") and \
+               config.has_option("versionhack", "tag"):
+                newVersionCommit = config.get("versionhack", "commit")
+                newVersionTag = config.get("versionhack", "tag")
+
     entries = []
 
     args = ["git", "log",
@@ -20,17 +45,26 @@ def collectEntries(baseCommit, baseVersion, kind):
     except:
         output = subprocess.check_output(args)
 
+
+    lastVersionTag = None
     for line in output.splitlines():
         (commit, name, email, date, revdate, subject) = line.split("\t")
         revdate = datetime.datetime.utcfromtimestamp(long(revdate)).strftime("%Y%m%d.%H%M%S")
 
+        if commit==newVersionCommit:
+            result = processVersionTag(newVersionTag)
+            if result:
+                newVersionOrigTag = lastVersionTag
+                (baseVersion, kind) = result
+
         for tag in subprocess.check_output(["git", "tag",
                                             "--points-at",
                                             commit]).splitlines():
-            m = versionTagRE.match(tag)
-            if m:
-                baseVersion = m.group(1)
-                kind = "release" if m.group(4) is None else "beta"
+            if tag!=newVersionOrigTag:
+                result = processVersionTag(tag)
+                if result:
+                    lastVersionTag = tag
+                    (baseVersion, kind) = result
 
         entries.append((commit, name, email, date, revdate, subject,
                         baseVersion, kind))
@@ -60,6 +94,7 @@ def genChangeLogEntries(f, entries, distribution):
     return (latestBaseVersion, latestKind)
 
 if __name__ == "__main__":
+
     distribution = sys.argv[2]
 
     #entries = collectEntries("8aade24147b5313f8241a8b42331442b7f40eef9", "2.2.4", "release")

--- a/linux/travis-build.sh
+++ b/linux/travis-build.sh
@@ -83,6 +83,8 @@ elif [ "$BUILD_TYPE" == "snap" ]; then
     fi
 elif [ "$BUILD_TYPE" == "debian" ]; then
     linux/debian/travis-build.sh "$@"
+elif [ "$BUILD_TYPE" == "win" ]; then
+    win/travis-build.sh "$@"
 else
     echo 'No $BUILD_TYPE defined'
     exit 1

--- a/win/opensuse-mingw-repo-location.patch
+++ b/win/opensuse-mingw-repo-location.patch
@@ -1,3 +1,14 @@
+Description: Update the repository location for MinGW.
+
+  Windows builds failed because this dependency was not at the specified
+  location. This patch can be applied to the client submodule to update the
+  Dockerfile with a path to MinGW for openSUSE Leap instead. This change has
+  been applied upstream in owncloud/client at 6be122e (PR owncloud/client#5900)
+  but is not included in the 2.3.3 release.
+
+Last-Update: 2017-10-04
+Author: Taylor Smith <tsmith@tsmithcreative.com>
+
 diff --git a/admin/win/docker/Dockerfile b/admin/win/docker/Dockerfile
 index 8e40a49..1629b97 100644
 --- a/admin/win/docker/Dockerfile

--- a/win/opensuse-mingw-repo-location.patch
+++ b/win/opensuse-mingw-repo-location.patch
@@ -1,0 +1,13 @@
+diff --git a/admin/win/docker/Dockerfile b/admin/win/docker/Dockerfile
+index 8e40a49..1629b97 100644
+--- a/admin/win/docker/Dockerfile
++++ b/admin/win/docker/Dockerfile
+@@ -8,7 +8,7 @@ ENV HOME /root
+ ENV REFRESHED_AT 20160421
+
+ RUN zypper --non-interactive --gpg-auto-import-keys refresh
+-RUN zypper --non-interactive --gpg-auto-import-keys ar http://download.opensuse.org/repositories/windows:/mingw/openSUSE_42.1/windows:mingw.repo
++RUN zypper --non-interactive --gpg-auto-import-keys ar http://download.opensuse.org/repositories/windows:/mingw/openSUSE_Leap_42.1/windows:mingw.repo
+ RUN zypper --non-interactive --gpg-auto-import-keys ar http://download.opensuse.org/repositories/isv:ownCloud:toolchains:mingw:win32:2.3/openSUSE_Leap_42.1/isv:ownCloud:toolchains:mingw:win32:2.3.repo
+ RUN zypper --non-interactive --gpg-auto-import-keys install cmake make mingw32-cross-binutils mingw32-cross-cpp mingw32-cross-gcc \
+                       mingw32-cross-gcc-c++ mingw32-cross-pkg-config mingw32-filesystem \

--- a/win/travis-build.sh
+++ b/win/travis-build.sh
@@ -9,19 +9,6 @@ shopt -s extglob
 TRAVIS_BUILD_STEP="$1"
 
 if [ "$TRAVIS_BUILD_STEP" == "install" ]; then
-    sudo apt-get update -q
-    sudo apt-get install -y devscripts cdbs osc
-
-    if test "$encrypted_585e03da75ed_key" -a "$encrypted_585e03da75ed_iv"; then
-        openssl aes-256-cbc -K $encrypted_585e03da75ed_key -iv $encrypted_585e03da75ed_iv -in linux/debian/signing-key.txt.enc -d | gpg --import
-        echo "DEBUILD_DPKG_BUILDPACKAGE_OPTS='-k7D14AA7B'" >> ~/.devscripts
-
-        openssl aes-256-cbc -K $encrypted_585e03da75ed_key -iv $encrypted_585e03da75ed_iv -in linux/debian/oscrc.enc -out ~/.oscrc -d
-    elif test "$encrypted_8da7a4416c7a_key" -a "$encrypted_8da7a4416c7a_iv"; then
-        openssl aes-256-cbc -K $encrypted_8da7a4416c7a_key -iv $encrypted_8da7a4416c7a_iv -in linux/debian/oscrc.enc -out ~/.oscrc -d
-        PPA=ppa:ivaradi/nextcloud-client-exp
-    fi
-
     # @TODO: This patch updates the repo location of mingw _in the origin repo_
     # because repositories/windows:/mingw/openSUSE_42.1/windows:mingw.repo has
     # been moved to openSUSE Leap 42.1. This has been applied upstream but is
@@ -38,23 +25,4 @@ elif [ "$TRAVIS_BUILD_STEP" == "script" ]; then
 
     docker build -t nextcloud-client-win32:${basever} client/admin/win/docker/
     docker run -v "$PWD:/home/user/" nextcloud-client-win32:${basever} /home/user/win/build.sh $(id -u)
-
-    cd ..
-
-    echo "$kind" > kind
-
-    if test "$kind" = "beta"; then
-        repo=client-beta
-    else
-        repo=client
-    fi
-
-    origsourceopt=""
-    #if ! wget http://ppa.launchpad.net/ivaradi/nextcloud-client-exp/ubuntu/pool/main/n/nextcloud-client/nextcloud-client_${basever}.orig.tar.bz2; then
-    if ! wget http://ppa.launchpad.net/nextcloud-devs/${repo}/ubuntu/pool/main/n/nextcloud-client/nextcloud-client_${basever}.orig.tar.bz2; then
-        mv client_theming nextcloud-client_${basever}
-        tar cjf nextcloud-client_${basever}.orig.tar.bz2 --exclude .git nextcloud-client_${basever}
-        mv nextcloud-client_${basever} client_theming
-        origsourceopt="-sa"
-    fi
 fi

--- a/win/travis-build.sh
+++ b/win/travis-build.sh
@@ -8,13 +8,6 @@ shopt -s extglob
 
 TRAVIS_BUILD_STEP="$1"
 
-PPA=ppa:nextcloud-devs/client
-PPA_BETA=ppa:nextcloud-devs/client-beta
-
-OBS_PROJECT=home:ivaradi
-OBS_PROJECT_BETA=home:ivaradi:beta
-OBS_PACKAGE=nextcloud-client
-
 if [ "$TRAVIS_BUILD_STEP" == "install" ]; then
     sudo apt-get update -q
     sudo apt-get install -y devscripts cdbs osc

--- a/win/travis-build.sh
+++ b/win/travis-build.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Adapted from the Debian travis-build.sh to test building a Windows binary
+# according to the build instructions in README.md
+
+set -xe
+shopt -s extglob
+
+TRAVIS_BUILD_STEP="$1"
+
+PPA=ppa:nextcloud-devs/client
+PPA_BETA=ppa:nextcloud-devs/client-beta
+
+OBS_PROJECT=home:ivaradi
+OBS_PROJECT_BETA=home:ivaradi:beta
+OBS_PACKAGE=nextcloud-client
+
+if [ "$TRAVIS_BUILD_STEP" == "install" ]; then
+    sudo apt-get update -q
+    sudo apt-get install -y devscripts cdbs osc
+
+    if test "$encrypted_585e03da75ed_key" -a "$encrypted_585e03da75ed_iv"; then
+        openssl aes-256-cbc -K $encrypted_585e03da75ed_key -iv $encrypted_585e03da75ed_iv -in linux/debian/signing-key.txt.enc -d | gpg --import
+        echo "DEBUILD_DPKG_BUILDPACKAGE_OPTS='-k7D14AA7B'" >> ~/.devscripts
+
+        openssl aes-256-cbc -K $encrypted_585e03da75ed_key -iv $encrypted_585e03da75ed_iv -in linux/debian/oscrc.enc -out ~/.oscrc -d
+    elif test "$encrypted_8da7a4416c7a_key" -a "$encrypted_8da7a4416c7a_iv"; then
+        openssl aes-256-cbc -K $encrypted_8da7a4416c7a_key -iv $encrypted_8da7a4416c7a_iv -in linux/debian/oscrc.enc -out ~/.oscrc -d
+        PPA=ppa:ivaradi/nextcloud-client-exp
+    fi
+
+elif [ "$TRAVIS_BUILD_STEP" == "script" ]; then
+    read basever kind <<<$(linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable)
+
+    docker build -t nextcloud-client-win32:${basever} client/admin/win/docker/
+    docker run -v "$PWD:/home/user/" nextcloud-client-win32:${basever} /home/user/win/build.sh $(id -u)
+
+    cd ..
+
+    echo "$kind" > kind
+
+    if test "$kind" = "beta"; then
+        repo=client-beta
+    else
+        repo=client
+    fi
+
+    origsourceopt=""
+    #if ! wget http://ppa.launchpad.net/ivaradi/nextcloud-client-exp/ubuntu/pool/main/n/nextcloud-client/nextcloud-client_${basever}.orig.tar.bz2; then
+    if ! wget http://ppa.launchpad.net/nextcloud-devs/${repo}/ubuntu/pool/main/n/nextcloud-client/nextcloud-client_${basever}.orig.tar.bz2; then
+        mv client_theming nextcloud-client_${basever}
+        tar cjf nextcloud-client_${basever}.orig.tar.bz2 --exclude .git nextcloud-client_${basever}
+        mv nextcloud-client_${basever} client_theming
+        origsourceopt="-sa"
+    fi
+fi

--- a/win/travis-build.sh
+++ b/win/travis-build.sh
@@ -30,9 +30,11 @@ if [ "$TRAVIS_BUILD_STEP" == "install" ]; then
     fi
 
     # @TODO: This patch updates the repo location of mingw _in the origin repo_
-    # because repositories/windows:/mingw/openSUSE_42.1/windows:mingw.repo does not
-    # exist anymore but it does exist in openSUSE Leap 42.1. This should be removed
-    # and the patch deleted when it is no longer needed to build.
+    # because repositories/windows:/mingw/openSUSE_42.1/windows:mingw.repo has
+    # been moved to openSUSE Leap 42.1. This has been applied upstream but is
+    # not included in their 2.3.3 tag. This should be removed and the patch
+    # deleted when it is no longer needed to build, presumably in the next
+    # release. See owncloud/client at 6be122e (PR owncloud/client#5900).
     cd client
     patch -p1 < ../win/opensuse-mingw-repo-location.patch
     cd ..

--- a/win/travis-build.sh
+++ b/win/travis-build.sh
@@ -29,6 +29,15 @@ if [ "$TRAVIS_BUILD_STEP" == "install" ]; then
         PPA=ppa:ivaradi/nextcloud-client-exp
     fi
 
+    # @TODO: This patch updates the repo location of mingw _in the origin repo_
+    # because repositories/windows:/mingw/openSUSE_42.1/windows:mingw.repo does not
+    # exist anymore but it does exist in openSUSE Leap 42.1. This should be removed
+    # and the patch deleted when it is no longer needed to build.
+    cd client
+    patch -p1 < ../win/opensuse-mingw-repo-location.patch
+    cd ..
+    # /end patch
+
 elif [ "$TRAVIS_BUILD_STEP" == "script" ]; then
     read basever kind <<<$(linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable)
 


### PR DESCRIPTION
Would resolve nextcloud/client_theming#202 and addresses nextcloud/server#5238 . The latest Nextcloud server version cannot sync files with client version 2.3.2 because of changes to WebDAV chunking. To resolve this issue, I updated the `client` submodule to origin tag `v2.3.3` and built a Windows package with the instructions from nextcloud/client_theming README.

I had a Docker build/installation error: _(resolved in dd25240)_

```
→  docker build -t nextcloud-client-win32:2.3.3 client/admin/win/docker/
[ ... ]
Step 7 : RUN zypper --non-interactive --gpg-auto-import-keys ar http://download.opensuse.org/repositories/windows:/mingw/openSUSE_42.1/windows:mingw.repo
 ---> Running in cdcadf211b75
File '/repositories/windows:/mingw/openSUSE_42.1/windows:mingw.repo' not found on medium 'http://download.opensuse.org/'

Abort, retry, ignore? [a/r/i/? shows all options] (a): a
Problem encountered while trying to read the file at the specified URI:
ABORT request: Aborting requested by user
The command '/bin/sh -c zypper --non-interactive --gpg-auto-import-keys ar http://download.opensuse.org/repositories/windows:/mingw/openSUSE_42.1/windows:mingw.repo' returned a non-zero code: 4
```

To resolve, I changed the Dockerfile _in the client submodule_ with an updated path on the openSUSE repository _(added in dd25240, same as upstream solution for owncloud/client#5900)_

``` diff
diff --git a/admin/win/docker/Dockerfile b/admin/win/docker/Dockerfile
index 8e40a49..1629b97 100644
--- a/admin/win/docker/Dockerfile
+++ b/admin/win/docker/Dockerfile
@@ -8,7 +8,7 @@ ENV HOME /root
 ENV REFRESHED_AT 20160421

 RUN zypper --non-interactive --gpg-auto-import-keys refresh
-RUN zypper --non-interactive --gpg-auto-import-keys ar http://download.opensuse.org/repositories/windows:/mingw/openSUSE_42.1/windows:mingw.repo
+RUN zypper --non-interactive --gpg-auto-import-keys ar http://download.opensuse.org/repositories/windows:/mingw/openSUSE_Leap_42.1/windows:mingw.repo
 RUN zypper --non-interactive --gpg-auto-import-keys ar http://download.opensuse.org/repositories/isv:ownCloud:toolchains:mingw:win32:2.3/openSUSE_Leap_42.1/isv:ownCloud:toolchains:mingw:win32:2.3.repo
 RUN zypper --non-interactive --gpg-auto-import-keys install cmake make mingw32-cross-binutils mingw32-cross-cpp mingw32-cross-gcc \
                       mingw32-cross-gcc-c++ mingw32-cross-pkg-config mingw32-filesystem \
```

Future upstream releases will have the fixed repo location.

The resulting Windows binary works fine for me and successfully synced the files that were giving me the `Precondition Failed` error.

_Disclaimer:_ I haven't built or tested binaries for other platforms.