### PR TITLE
Removed trusty and yakkety.

### DIFF
--- a/linux/debian/travis-build.sh
+++ b/linux/debian/travis-build.sh
@@ -51,7 +51,7 @@ elif [ "$TRAVIS_BUILD_STEP" == "script" ]; then
         origsourceopt="-sa"
     fi
 
-    for distribution in trusty xenial yakkety zesty artful stable; do
+    for distribution in xenial zesty artful stable; do
         rm -rf nextcloud-client_${basever}
         cp -a client_theming nextcloud-client_${basever}
 


### PR DESCRIPTION
v2.3.3 cannot be compiled on Trusty due it requesting the Qt5 version
of the keychain library.

Yakkety is not supported anymore on Launchpad.