### PR TITLE
travis: use different condition and name for deploying on debian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,13 @@ deploy:
     skip_cleanup: true
     script: linux/travis-build.sh snap_store_deploy
     on:
-      condition: ($BUILD_TYPE = snap && -n "$SNAPCRAFT_CONFIG_KEY" && -n "$SNAPCRAFT_CONFIG_IV") || $BUILD_TYPE = debian
+      condition: ($BUILD_TYPE = snap && -n "$SNAPCRAFT_CONFIG_KEY" && -n "$SNAPCRAFT_CONFIG_IV")
+
+  - provider: script
+    skip_cleanup: true
+    script: linux/travis-build.sh ppa_deploy
+    on:
+      condition: ($BUILD_TYPE = debian)
 
 branches:
   except:

--- a/linux/debian/travis-build.sh
+++ b/linux/debian/travis-build.sh
@@ -81,7 +81,7 @@ elif [ "$TRAVIS_BUILD_STEP" == "script" ]; then
         cd ..
     done
 
-elif [ "$TRAVIS_BUILD_STEP" == "snap_store_deploy" ]; then
+elif [ "$TRAVIS_BUILD_STEP" == "ppa_deploy" ]; then
     cd ..
 
     kind=`cat kind`


### PR DESCRIPTION
snap naming doesn't make any sense in debian. Juts add another deploy provider.