### PR TITLE
Changelog generator script fix

### DIFF
--- a/linux/debian/scripts/git2changelog.py
+++ b/linux/debian/scripts/git2changelog.py
@@ -64,7 +64,9 @@ def collectEntries(baseCommit, baseVersion, kind):
                 result = processVersionTag(tag)
                 if result:
                     lastVersionTag = tag
-                    (baseVersion, kind) = result
+                    (b, k) = result
+                    if b>baseVersion or (k=="release" and kind=="beta"):
+                        (baseVersion, kind) = result
 
         entries.append((commit, name, email, date, revdate, subject,
                         baseVersion, kind))


### PR DESCRIPTION
Even though the current code is already tagged v2.3.3, the changelog script currently considers it a beta release, because the same commit to which v2.3.3 is applied is also pointed to by the v2.3.3-beta2 tag. 

This commit fixes the changelog generator script to handle this situation.