### PR TITLE
Dolphin plugin path correction

### DIFF
--- a/linux/debian/nextcloud-client/debian.artful/nextcloud-client-dolphin.install
+++ b/linux/debian/nextcloud-client/debian.artful/nextcloud-client-dolphin.install
@@ -1,4 +1,0 @@
-usr/lib/*/libnextclouddolphinpluginhelper.so
-usr/lib/*/qt5/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
-usr/lib/*/qt5/plugins/nextclouddolphinactionplugin.so
-usr/share/kservices5/nextclouddolphinactionplugin.desktop

--- a/linux/debian/nextcloud-client/debian.yakkety/nextcloud-client-dolphin.install
+++ b/linux/debian/nextcloud-client/debian.yakkety/nextcloud-client-dolphin.install
@@ -1,4 +1,0 @@
-usr/lib/*/libnextclouddolphinpluginhelper.so
-usr/lib/*/qt5/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
-usr/lib/*/qt5/plugins/nextclouddolphinactionplugin.so
-usr/share/kservices5/nextclouddolphinactionplugin.desktop

--- a/linux/debian/nextcloud-client/debian.zesty/nextcloud-client-dolphin.install
+++ b/linux/debian/nextcloud-client/debian.zesty/nextcloud-client-dolphin.install
@@ -1,4 +1,0 @@
-usr/lib/*/libnextclouddolphinpluginhelper.so
-usr/lib/*/qt5/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
-usr/lib/*/qt5/plugins/nextclouddolphinactionplugin.so
-usr/share/kservices5/nextclouddolphinactionplugin.desktop

--- a/linux/debian/nextcloud-client/debian/nextcloud-client-dolphin.install
+++ b/linux/debian/nextcloud-client/debian/nextcloud-client-dolphin.install
@@ -1,4 +1,4 @@
 usr/lib/*/libnextclouddolphinpluginhelper.so
-usr/lib/*/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
-usr/lib/*/plugins/nextclouddolphinactionplugin.so
+usr/lib/*/qt5/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
+usr/lib/*/qt5/plugins/nextclouddolphinactionplugin.so
 usr/share/kservices5/nextclouddolphinactionplugin.desktop

--- a/linux/debian/nextcloud-client/debian/patches/series
+++ b/linux/debian/nextcloud-client/debian/patches/series
@@ -1,2 +1,3 @@
 fix-application-icon-name.patch
 fix-syncstate-appname.patch
+set-kde-use-qt-sys-path.patch

--- a/linux/debian/nextcloud-client/debian/patches/set-kde-use-qt-sys-path.patch
+++ b/linux/debian/nextcloud-client/debian/patches/set-kde-use-qt-sys-path.patch
@@ -1,0 +1,10 @@
+--- nextcloud-client_2.3.0.orig/client/shell_integration/dolphin/CMakeLists.txt	2018-02-25 13:15:53.775971301 +0100
++++ nextcloud-client_2.3.0/client/shell_integration/dolphin/CMakeLists.txt	2018-02-25 13:15:57.584003567 +0100
+@@ -4,6 +4,7 @@
+ include(FeatureSummary)
+ set(QT_MIN_VERSION "5.3.0")
+ set(KF5_MIN_VERSION "5.16.0")
++set(KDE_INSTALL_USE_QT_SYS_PATHS ON CACHE BOOL "Install the plugin in the right directory")
+ 
+ find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Network)
+ 


### PR DESCRIPTION
When building for Xenial the Dolphin plugins go into the incorrect directory. This patch sets the KDE_INSTALL_USE_QT_SYS_PATHS cmake variable to ON, which seems to be the most generic way to solve this issue.

This fixes nexcloud/client#147.